### PR TITLE
Fixes for the "future meetups" mechanism

### DIFF
--- a/pyvodb/load.py
+++ b/pyvodb/load.py
@@ -9,6 +9,7 @@ import yaml
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql.expression import select
+from dateutil import rrule
 
 from . import tables
 
@@ -133,9 +134,11 @@ def load_from_dict(db, data, metadata):
 
             series = series_dir['series']
             recurrence = series.get('recurrence')
-            if 'recurrence' in series:
+            if recurrence:
+                rrule_str = recurrence['rrule']
+                rrule.rrulestr(rrule_str)  # check rrule syntax
                 recurrence_attrs = {
-                    'recurrence_rule': recurrence['rrule'],
+                    'recurrence_rule': rrule_str,
                     'recurrence_scheme': recurrence['scheme'],
                     'recurrence_description_cs': recurrence['description']['cs'],
                     'recurrence_description_en': recurrence['description']['en'],

--- a/test_pyvodb/conftest.py
+++ b/test_pyvodb/conftest.py
@@ -3,6 +3,8 @@ import glob
 
 import pytest
 
+from pyvodb.load import get_db
+
 @pytest.fixture(scope='module')
 def data_directory():
     return os.path.join(os.path.dirname(__file__), 'data')
@@ -14,3 +16,7 @@ def get_yaml_data(data_directory):
         with open(filename) as f:
             return f.read()
     return _get_yaml_data
+
+@pytest.fixture(scope='module')
+def db(data_directory):
+    return get_db(data_directory)

--- a/test_pyvodb/data/series/brno-pyvo-rruletest/events/2012-11-05.yaml
+++ b/test_pyvodb/data/series/brno-pyvo-rruletest/events/2012-11-05.yaml
@@ -1,0 +1,7 @@
+city: brno
+start: 2012-11-05
+name: Brněnské PyVo
+description: "Let's assume this took place on the first Monday of the month"
+venue: u-drevaka
+talks: []
+urls: []

--- a/test_pyvodb/data/series/brno-pyvo-rruletest/series.yaml
+++ b/test_pyvodb/data/series/brno-pyvo-rruletest/series.yaml
@@ -1,0 +1,11 @@
+name: Brněnské Pyvo (rrule test data)
+city: brno
+description:
+  cs: ""
+  en: ""
+recurrence:
+  scheme: monthly
+  rrule: RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=-1TH;BYHOUR=19;BYMINUTE=0;BYSECOND=0
+  description:
+    cs: Brněnské Pyvo bývá každý poslední čtvrtek v měsíci.
+    en: Pyvo Brno is usually held on the last Thursday of each month.

--- a/test_pyvodb/data/series/brno-pyvo/series.yaml
+++ b/test_pyvodb/data/series/brno-pyvo/series.yaml
@@ -15,3 +15,9 @@ organizer-info:
     mail: encukou@gmail.com
   - name: Honza Javorek
     mail: mail@honzajavorek.cz
+recurrence:
+  scheme: monthly
+  rrule: RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=-1TH;BYHOUR=19;BYMINUTE=0;BYSECOND=0
+  description:
+    cs: Brněnské Pyvo bývá každý poslední čtvrtek v měsíci.
+    en: Pyvo Brno is usually held on the last Thursday of each month.

--- a/test_pyvodb/data/series/praha-pyvo/series.yaml
+++ b/test_pyvodb/data/series/praha-pyvo/series.yaml
@@ -32,3 +32,5 @@ organizer-info:
     mail: whiskybar@gmail.com
   - name: Aleš Zoulek
     mail: ales.zoulek@gmail.com
+
+# recurrence: -- missing intentionally

--- a/test_pyvodb/test_load.py
+++ b/test_pyvodb/test_load.py
@@ -5,10 +5,6 @@ from sqlalchemy.exc import IntegrityError
 from pyvodb.load import get_db, load_from_directory
 from pyvodb.tables import Event, City, Venue
 
-@pytest.fixture(scope='module')
-def db(data_directory):
-    return get_db(data_directory)
-
 @pytest.fixture
 def empty_db(data_directory):
     return get_db(None)

--- a/test_pyvodb/test_logic.py
+++ b/test_pyvodb/test_logic.py
@@ -1,0 +1,71 @@
+import datetime
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from dateutil import tz
+
+from pyvodb.load import get_db, load_from_directory
+from pyvodb.tables import Series
+
+CET = tz.gettz('Europe/Prague')
+
+def test_recurrence(db):
+    query = db.query(Series)
+    query = query.filter(Series.slug == 'brno-pyvo')
+    series = query.one()
+    next_occurences = series.next_occurrences(
+        since=datetime.date(2017, 8, 15),
+        n=5,
+    )
+    assert list(next_occurences) == [
+        datetime.datetime(2017, 8, 31, 19, tzinfo=CET),
+        datetime.datetime(2017, 9, 28, 19, tzinfo=CET),
+        datetime.datetime(2017, 10, 26, 19, tzinfo=CET),
+        datetime.datetime(2017, 11, 30, 19, tzinfo=CET),
+        datetime.datetime(2017, 12, 28, 19, tzinfo=CET),
+    ]
+    assert series.recurrence_description_cs == (
+        'Brněnské Pyvo bývá každý poslední čtvrtek v měsíci.')
+
+def test_recurrence_monthly(db):
+    """Test the case where Pyvo already took place that month, but at a
+    non-traditional date.
+    Future meetup dates should not include that month.
+    """
+    query = db.query(Series)
+    query = query.filter(Series.slug == 'brno-pyvo-rruletest')
+    series = query.one()
+    next_occurences = series.next_occurrences(
+        since=datetime.date(2012, 11, 15),
+        n=2,
+    )
+    assert list(next_occurences) == [
+        datetime.datetime(2012, 12, 27, 19, tzinfo=CET),
+        datetime.datetime(2013, 1, 31, 19, tzinfo=CET),
+    ]
+
+def test_recurrence_after(db):
+    """Test that meetup dates are only predicted after the last event.
+    """
+    query = db.query(Series)
+    query = query.filter(Series.slug == 'brno-pyvo-rruletest')
+    series = query.one()
+    next_occurences = series.next_occurrences(
+        since=datetime.date(1999, 1, 1),
+        n=2,
+    )
+    assert list(next_occurences) == [
+        datetime.datetime(2012, 12, 27, 19, tzinfo=CET),
+        datetime.datetime(2013, 1, 31, 19, tzinfo=CET),
+    ]
+
+def test_no_recurrence(db):
+    query = db.query(Series)
+    query = query.filter(Series.slug == 'praha-pyvo')
+    # In the test data, recurrence info for praha-pyvo is missing
+    series = query.one()
+    next_occurences = series.next_occurrences(
+        since=datetime.date(2017, 8, 1),
+        n=5,
+    )
+    assert list(next_occurences) == []


### PR DESCRIPTION
## Check rrule syntax when loading
The "tests" for pyvo-data involve loading the DB. This patch makes loading fail when the data includes an invalid recurrence rule for meetups.

Recurrence rules encode information like ["last Thursday of a month"](https://github.com/pyvec/pyvo-data/blob/master/series/brno-pyvo/series.yaml#L22) or ["every Thurstay except the last"](https://github.com/pyvec/pyvo-data/blob/master/series/nepyvo/series.yaml#L23), and this is used to get expected dates for future meetups on pyvo.cz. They're quite easy to get wrong.

## Fix & test "predictions" for upcoming meetups

Should solve https://github.com/pyvec/pyvo.cz/issues/58 -- tentative dates for meetups that aren't scheduled yet don't appear in the current month. Tests included (finally).