### PR TITLE
Add videometadata exporter

### DIFF
--- a/pyvodb/cli/__init__.py
+++ b/pyvodb/cli/__init__.py
@@ -1,5 +1,6 @@
 from . import calendar
 from . import show
+from . import videometadata
 from .top import cli, main
 
-__all__ = ['cli', 'main', 'calendar', 'show']
+__all__ = ['cli', 'main', 'calendar', 'show', 'videometadata']

--- a/pyvodb/cli/videometadata.py
+++ b/pyvodb/cli/videometadata.py
@@ -1,0 +1,71 @@
+import os.path
+from collections import OrderedDict
+import yaml
+import click
+
+from slugify import slugify
+from pyvodb.cli.top import cli
+from pyvodb.cli import cliutil
+
+
+yaml.SafeDumper.add_representer(OrderedDict,
+    lambda dumper, value: dumper.represent_dict(value.items()))
+
+
+@cli.command()
+@click.argument('city')
+@click.argument('date')
+@click.argument('outpath', default=".")
+@click.pass_context
+def videometadata(ctx, city, date, outpath):
+    """Generate metadata for video records.
+
+    city: The meetup series.
+
+    \b
+    date: The date. May be:
+        - YYYY-MM-DD or YY-MM-DD (e.g. 2015-08-27)
+        - YYYY-MM or YY-MM (e.g. 2015-08)
+        - MM (e.g. 08): the given month in the current year
+        - pN (e.g. p1): show the N-th last meetup
+    """
+    db = ctx.obj['db']
+    today = ctx.obj['now'].date()
+
+    event = cliutil.get_event(db, city, date, today)
+
+    data = event.as_dict()
+    cliutil.handle_raw_output(ctx, data)
+
+    evdir = "{}-{}".format(event.city.name, event.slug)
+    print(evdir)
+    print()
+
+    if event.talks:
+        talknum = 1
+        for talk in event.talks:
+            config = OrderedDict()
+            config['speaker'] = ', '.join(s.name for s in talk.speakers)
+            config['title'] = talk.title
+            config['lightning'] = talk.is_lightning
+            config['speaker_only'] = False
+            config['widescreen'] = False
+            config['speaker_vid'] = "*.MTS"
+            config['screen_vid'] = "*.ts"
+            config['event'] = event.name
+            if event.number:
+                config['event'] += " #{}".format(event.number)
+            config['date'] = event.date.strftime("%Y-%m-%d")
+            config['url'] = "https://pyvo.cz/{}/{}/".format(event.series_slug,
+                                                            event.slug)
+            confyaml = yaml.safe_dump(config, default_flow_style=False,
+                                      allow_unicode=True)
+            talkdir = "{:02d}-{}".format(talknum, slugify(talk.title))
+            print(talkdir)
+            print(confyaml)
+            talknum += 1
+            p = os.path.join(outpath, evdir, talkdir)
+            if not os.path.exists(p):
+                os.makedirs(p)
+            with open(os.path.join(p, 'config.yaml'), 'w') as outf:
+                outf.write(confyaml)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requires = [
     'python-dateutil >= 2.5, <3.0',
     'click >= 6.6, <7.0',
     'czech-holidays',
-    'blessings >= 1.6, < 2.0',
+    'awesome-slugify',
 ]
 
 tests_require = ['pytest']


### PR DESCRIPTION
I've extended the tool to be able to generate directory structure and `config.yaml` files per each talk, that can be later fed into [talk-video-maker](https://github.com/encukou/talk-video-maker) to generate video recordings.

It works for me. I'm aware this probably does not meet code quality standards yet, so I'll be happy to follow any advice how to make this mergeable.