### PR TITLE
Better regexp for YouTube links

### DIFF
--- a/pyvodb/tables.py
+++ b/pyvodb/tables.py
@@ -21,7 +21,12 @@ TableBase = declarative_base(metadata=metadata)
 
 CET = tz.gettz('Europe/Prague')
 
-YOUTUBE_RE = re.compile('https?://www.youtube.com/watch\?v=([-0-9a-zA-Z_]+)')
+YOUTUBE_RE = re.compile(r'''(?x)https?://
+                        (?:
+                            (?:www\.youtube\.com/watch\?v=)|
+                            (?:youtu\.be/)
+                        )
+                        ([-0-9a-zA-Z_]+)''')
 
 
 def date_property(name):

--- a/test_pyvodb/data/series/brno-pyvo/events/2013-05-30-gui.yaml
+++ b/test_pyvodb/data/series/brno-pyvo/events/2013-05-30-gui.yaml
@@ -11,6 +11,7 @@ talks:
   - http://lanyrd.com/2013/brnenske-pyvo-brug-kvetnove/schxdm/
   coverage:
   - video: http://www.youtube.com/watch?v=HDmCGUKfe7Y
+  - video: https://youtu.be/HDmCGUKfe7Y
 - title: PySide & Qt
   speakers:
   - Petr Viktorin

--- a/test_pyvodb/test_load.py
+++ b/test_pyvodb/test_load.py
@@ -213,6 +213,7 @@ def test_talk_links(db):
     assert {s.kind: s.url for s in talk.links} == {
         'talk': 'http://lanyrd.com/2013/brnenske-pyvo-brug-kvetnove/schxdm/',
         'video': 'http://www.youtube.com/watch?v=HDmCGUKfe7Y',
+        'video': 'https://youtu.be/HDmCGUKfe7Y',
     }
 
 def test_talk_youtube_id(db):
@@ -230,7 +231,7 @@ def test_talk_link_youtube_id(db):
     query = query.filter(Event.day == 30)
     event = query.one()
     talk = event.talks[0]
-    assert [s.youtube_id for s in talk.links] == [None, 'HDmCGUKfe7Y']
+    assert [s.youtube_id for s in talk.links] == [None, 'HDmCGUKfe7Y', 'HDmCGUKfe7Y']
 
 def test_talk_description(db):
     query = db.query(Event)


### PR DESCRIPTION
I've found out YouTube links are only accepted in the long form. This allows short URLs as well. Probably not necessary, but still nice to have ;)