### PR TITLE
Travis: Allow failures for Python nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
   - "3.6"
   - "nightly"
 
+matrix:
+  allow_failures:
+    - python: 'nightly'
+
 install:
   - pip install -e.
   - pip install pytest


### PR DESCRIPTION
PyYAML seems to have trouble compiling on Python 3.7 beta